### PR TITLE
NavigationController 화면전환 및 TableViewCell SwipeAction

### DIFF
--- a/SimpleContact.xcodeproj/project.pbxproj
+++ b/SimpleContact.xcodeproj/project.pbxproj
@@ -10,6 +10,8 @@
 		0956E6642653FFED00D5B4F9 /* EditViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0956E6632653FFED00D5B4F9 /* EditViewController.swift */; };
 		0958A30D2654D00100D054CD /* EditView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0958A30C2654D00100D054CD /* EditView.swift */; };
 		0958A30F2657BE7400D054CD /* MainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0958A30E2657BE7400D054CD /* MainViewController.swift */; };
+		09FB2931265FCCFC00752300 /* MainViewTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09FB2930265FCCFC00752300 /* MainViewTableViewCell.swift */; };
+		09FB2935265FCD7E00752300 /* Person.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09FB2934265FCD7E00752300 /* Person.swift */; };
 		6B87C4742653EE750000A70A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B87C4732653EE750000A70A /* AppDelegate.swift */; };
 		6B87C4762653EE750000A70A /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B87C4752653EE750000A70A /* SceneDelegate.swift */; };
 		6B87C47D2653EE760000A70A /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 6B87C47C2653EE760000A70A /* Assets.xcassets */; };
@@ -21,6 +23,8 @@
 		0956E6632653FFED00D5B4F9 /* EditViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditViewController.swift; sourceTree = "<group>"; };
 		0958A30C2654D00100D054CD /* EditView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditView.swift; sourceTree = "<group>"; };
 		0958A30E2657BE7400D054CD /* MainViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainViewController.swift; sourceTree = "<group>"; };
+		09FB2930265FCCFC00752300 /* MainViewTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainViewTableViewCell.swift; sourceTree = "<group>"; };
+		09FB2934265FCD7E00752300 /* Person.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Person.swift; sourceTree = "<group>"; };
 		6B87C4702653EE750000A70A /* SimpleContact.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SimpleContact.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		6B87C4732653EE750000A70A /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		6B87C4752653EE750000A70A /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -45,8 +49,17 @@
 			isa = PBXGroup;
 			children = (
 				0958A30C2654D00100D054CD /* EditView.swift */,
+				09FB2930265FCCFC00752300 /* MainViewTableViewCell.swift */,
 			);
 			path = View;
+			sourceTree = "<group>";
+		};
+		09FB2933265FCD4700752300 /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				09FB2934265FCD7E00752300 /* Person.swift */,
+			);
+			path = Model;
 			sourceTree = "<group>";
 		};
 		6B87C4672653EE750000A70A = {
@@ -68,6 +81,7 @@
 		6B87C4722653EE750000A70A /* SimpleContact */ = {
 			isa = PBXGroup;
 			children = (
+				09FB2933265FCD4700752300 /* Model */,
 				0956E6602653FCE500D5B4F9 /* View */,
 				6B87C4872653EECD0000A70A /* Controller */,
 				6B87C4732653EE750000A70A /* AppDelegate.swift */,
@@ -167,7 +181,9 @@
 				0958A30D2654D00100D054CD /* EditView.swift in Sources */,
 				6B87C4742653EE750000A70A /* AppDelegate.swift in Sources */,
 				6B87C4762653EE750000A70A /* SceneDelegate.swift in Sources */,
+				09FB2935265FCD7E00752300 /* Person.swift in Sources */,
 				0958A30F2657BE7400D054CD /* MainViewController.swift in Sources */,
+				09FB2931265FCCFC00752300 /* MainViewTableViewCell.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/SimpleContact/Base.lproj/LaunchScreen.storyboard
+++ b/SimpleContact/Base.lproj/LaunchScreen.storyboard
@@ -1,8 +1,10 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -11,15 +13,20 @@
             <objects>
                 <viewController id="01J-lp-oVM" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     </view>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="53" y="375"/>
+            <point key="canvasLocation" x="52.173913043478265" y="375"/>
         </scene>
     </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>

--- a/SimpleContact/Controller/EditViewController.swift
+++ b/SimpleContact/Controller/EditViewController.swift
@@ -122,6 +122,8 @@ class EditViewController: UIViewController {
     }
     
     @objc private func back(_ sender: Any){
+        // 현재 뷰를 메모리 상 제거 하고 이전 뷰로 돌아감 네비게이션 스택을 한번 pop처리
+        navigationController?.popViewController(animated: true)
         print("back 클릭")
     }
     
@@ -158,14 +160,14 @@ class EditViewController: UIViewController {
         
         ImageView.snp.makeConstraints {
             $0.width.height.equalTo(120)
-            $0.top.equalTo(view).offset(90)
+            $0.top.equalTo(view.safeAreaLayoutGuide).offset(10)
             $0.left.equalTo(40)
         }
         
         nameLabel.snp.makeConstraints {
             $0.width.equalTo(100)
             $0.height.equalTo(30)
-            $0.top.equalTo(100)
+            $0.top.equalTo(view.safeAreaLayoutGuide)
             $0.trailing.equalTo(-80)
         }
         
@@ -179,7 +181,7 @@ class EditViewController: UIViewController {
         favoriteLabel.snp.makeConstraints {
             $0.width.equalTo(100)
             $0.height.equalTo(30)
-            $0.top.equalTo(280)
+            $0.top.equalTo(view.safeAreaLayoutGuide).offset(200)
             $0.centerX.equalTo(view)
         }
         

--- a/SimpleContact/Controller/MainViewController.swift
+++ b/SimpleContact/Controller/MainViewController.swift
@@ -154,6 +154,9 @@ class MainViewController: UIViewController {
         print("favorite button이 터치되었습니다.")
     }
     @objc private func addButtonTapped(_ sender: UIButton) {
+        let editViewController = EditViewController()
+        // EditViewController push
+        self.navigationController?.pushViewController(editViewController, animated: true)
         print("add button이 터치되었습니다.")
     }
 }

--- a/SimpleContact/Controller/MainViewController.swift
+++ b/SimpleContact/Controller/MainViewController.swift
@@ -146,6 +146,7 @@ class MainViewController: UIViewController {
         tableView.register(MainViewTableViewCell.self, forCellReuseIdentifier: MainViewTableViewCell.identifier)
     }
     
+    
     // MARK: - Selector
     @objc private func allButtonTapped(_ sender: UIButton) {
         print("all button이 터치되었습니다.")
@@ -206,7 +207,44 @@ extension MainViewController: UITableViewDelegate {
         guard let cell = tableView.cellForRow(at: indexPath) else { return }
         cell.selectionStyle = .none
     }
+  
+
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         print("\(indexPath.row)번째 cell이 터치되었습니다")
     }
+    
+    func tableView(_ tableView: UITableView, leadingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
+        // leadungSwipe는 왼쪽 스와이프
+        
+        let like = UIContextualAction(style: .normal, title: "like") { (UIContextualAction, UIView, success: @escaping(Bool) -> Void) in
+            print("Like 클릭")
+            success(true)
+        }
+        like.image = UIImage(systemName: "star")
+        like.title = nil
+        like.backgroundColor = .systemPink
+        
+        return UISwipeActionsConfiguration(actions: [like])
+    }
+    
+    func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
+            // trailingSwipe는 오른쪽 스와이프
+            
+            let edit = UIContextualAction(style: .normal, title: "Edit") { (UIContextualAction, UIView, success: @escaping (Bool) -> Void) in
+                print("Edit 클릭")
+                success(true)
+            }
+            edit.backgroundColor = .systemBlue
+            
+            
+            let delete = UIContextualAction(style: .normal, title: "Delete") { (UIContextualAction, UIView, success: @escaping (Bool) -> Void) in
+                print("Delete 클릭")
+                success(true)
+            }
+            delete.backgroundColor = .systemRed
+            
+            //actions배열 인덱스 0이 오른쪽에 붙어서 나옴
+            return UISwipeActionsConfiguration(actions:[delete, edit])
+        }
 }
+

--- a/SimpleContact/SceneDelegate.swift
+++ b/SimpleContact/SceneDelegate.swift
@@ -14,10 +14,26 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         guard let scene = (scene as? UIWindowScene) else { return }
+
+
+        
+        // 윈도우의 크기 설정
+        window = UIWindow(frame: UIScreen.main.bounds)
+        // 뷰컨트롤러 인스턴스 가져오기
+        let VC = MainViewController()
+        
+        // 네비게이션 컨트롤러 설정
+        let navVC = UINavigationController(rootViewController: VC)
         window = UIWindow(windowScene: scene)
         
-        window?.rootViewController = MainViewController()
+        // 뿌리 뷰컨트롤러를 설정
+        window?.rootViewController = navVC
+        
+        // 설정한 윈도우를 보이게 끔 설정
         window?.makeKeyAndVisible()
+        
+        // 윈도우씬 설정
+        window?.windowScene = scene
     }
 
     func sceneDidDisconnect(_ scene: UIScene) {

--- a/SimpleContact/View/MainViewTableViewCell.swift
+++ b/SimpleContact/View/MainViewTableViewCell.swift
@@ -11,6 +11,7 @@ import UIKit
 class MainViewTableViewCell: UITableViewCell {
     // MARK: - Property
 
+
     static let identifier = String(describing: MainViewTableViewCell.self)
     
     private lazy var personImageView: UIImageView = {
@@ -122,6 +123,8 @@ class MainViewTableViewCell: UITableViewCell {
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
+    
+    
     
     // MARK: - Helper
 


### PR DESCRIPTION
## 작업 내용(자세히!)

1. SceneDelegate에서 네비게이션 컨트롤러 설정을 하고 MainViewController를 뿌리 뷰 컨트롤러로 지정했습니다.
2. MainViewController의 addButton을 터치시 EditViewController를 push, EditViewController의 Back버튼 클릭시 이전화면으로 pop
3. MainTableViewCell의 왼쪽, 오른쪽으로 스와이프시 즐겨찾기, 편집, 삭제버튼 추가
 
## 결과(스크린샷 또는 기대결과)
<img width="428" alt="image" src="https://user-images.githubusercontent.com/73055887/119844729-a5c81780-bf43-11eb-9633-65857dffdf34.png">
<img width="418" alt="image" src="https://user-images.githubusercontent.com/73055887/119844764-ad87bc00-bf43-11eb-8267-8781bbd38972.png">
