### PR TITLE
Feature/contact

### DIFF
--- a/Contact+CoreDataClass.swift
+++ b/Contact+CoreDataClass.swift
@@ -1,0 +1,15 @@
+//
+//  Contact+CoreDataClass.swift
+//  SimpleContact
+//
+//  Created by 김두리 on 2021/05/31.
+//
+//
+
+import Foundation
+import CoreData
+
+@objc(Contact)
+public class Contact: NSManagedObject {
+
+}

--- a/Contact+CoreDataProperties.swift
+++ b/Contact+CoreDataProperties.swift
@@ -1,0 +1,28 @@
+//
+//  Contact+CoreDataProperties.swift
+//  SimpleContact
+//
+//  Created by 김두리 on 2021/05/31.
+//
+//
+
+import Foundation
+import CoreData
+
+
+extension Contact {
+
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<Contact> {
+        return NSFetchRequest<Contact>(entityName: "Contact")
+    }
+
+    @NSManaged public var name: String?
+    @NSManaged public var memo: String?
+    @NSManaged public var favorite: Bool
+    @NSManaged public var phone: String?
+
+}
+
+extension Contact : Identifiable {
+
+}

--- a/SimpleContact.xcodeproj/project.pbxproj
+++ b/SimpleContact.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		6B87C47D2653EE760000A70A /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 6B87C47C2653EE760000A70A /* Assets.xcassets */; };
 		6B87C4802653EE760000A70A /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 6B87C47E2653EE760000A70A /* LaunchScreen.storyboard */; };
 		6B87C48C2653F11B0000A70A /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = 6B87C48B2653F11B0000A70A /* SnapKit */; };
+		C12E7B0B2661373F008934ED /* Person.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = C12E7B092661373F008934ED /* Person.xcdatamodeld */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -31,6 +32,7 @@
 		6B87C47C2653EE760000A70A /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		6B87C47F2653EE760000A70A /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		6B87C4812653EE760000A70A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		C12E7B0A2661373F008934ED /* Person.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = Person.xcdatamodel; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -58,6 +60,7 @@
 			isa = PBXGroup;
 			children = (
 				09FB2934265FCD7E00752300 /* Person.swift */,
+				C12E7B092661373F008934ED /* Person.xcdatamodeld */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -179,6 +182,7 @@
 			files = (
 				0956E6642653FFED00D5B4F9 /* EditViewController.swift in Sources */,
 				0958A30D2654D00100D054CD /* EditView.swift in Sources */,
+				C12E7B0B2661373F008934ED /* Person.xcdatamodeld in Sources */,
 				6B87C4742653EE750000A70A /* AppDelegate.swift in Sources */,
 				6B87C4762653EE750000A70A /* SceneDelegate.swift in Sources */,
 				09FB2935265FCD7E00752300 /* Person.swift in Sources */,
@@ -323,7 +327,9 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 2DC647Y566;
 				INFOPLIST_FILE = SimpleContact/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -341,7 +347,9 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 2DC647Y566;
 				INFOPLIST_FILE = SimpleContact/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -394,6 +402,19 @@
 			productName = SnapKit;
 		};
 /* End XCSwiftPackageProductDependency section */
+
+/* Begin XCVersionGroup section */
+		C12E7B092661373F008934ED /* Person.xcdatamodeld */ = {
+			isa = XCVersionGroup;
+			children = (
+				C12E7B0A2661373F008934ED /* Person.xcdatamodel */,
+			);
+			currentVersion = C12E7B0A2661373F008934ED /* Person.xcdatamodel */;
+			path = Person.xcdatamodeld;
+			sourceTree = "<group>";
+			versionGroupType = wrapper.xcdatamodel;
+		};
+/* End XCVersionGroup section */
 	};
 	rootObject = 6B87C4682653EE750000A70A /* Project object */;
 }

--- a/SimpleContact.xcodeproj/project.pbxproj
+++ b/SimpleContact.xcodeproj/project.pbxproj
@@ -17,7 +17,10 @@
 		6B87C47D2653EE760000A70A /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 6B87C47C2653EE760000A70A /* Assets.xcassets */; };
 		6B87C4802653EE760000A70A /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 6B87C47E2653EE760000A70A /* LaunchScreen.storyboard */; };
 		6B87C48C2653F11B0000A70A /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = 6B87C48B2653F11B0000A70A /* SnapKit */; };
-		C12E7B0B2661373F008934ED /* Person.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = C12E7B092661373F008934ED /* Person.xcdatamodeld */; };
+		C1801E162665071400D4FBD2 /* PersistenceManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1801E152665071400D4FBD2 /* PersistenceManager.swift */; };
+		C1801E382665125D00D4FBD2 /* Contact.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = C1801E362665125D00D4FBD2 /* Contact.xcdatamodeld */; };
+		C1801E3C266512BD00D4FBD2 /* Contact+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1801E3A266512BD00D4FBD2 /* Contact+CoreDataClass.swift */; };
+		C1801E3D266512BD00D4FBD2 /* Contact+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1801E3B266512BD00D4FBD2 /* Contact+CoreDataProperties.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -32,7 +35,10 @@
 		6B87C47C2653EE760000A70A /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		6B87C47F2653EE760000A70A /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		6B87C4812653EE760000A70A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		C12E7B0A2661373F008934ED /* Person.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = Person.xcdatamodel; sourceTree = "<group>"; };
+		C1801E152665071400D4FBD2 /* PersistenceManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistenceManager.swift; sourceTree = "<group>"; };
+		C1801E372665125D00D4FBD2 /* Contact.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = Contact.xcdatamodel; sourceTree = "<group>"; };
+		C1801E3A266512BD00D4FBD2 /* Contact+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Contact+CoreDataClass.swift"; sourceTree = "<group>"; };
+		C1801E3B266512BD00D4FBD2 /* Contact+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Contact+CoreDataProperties.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -60,7 +66,8 @@
 			isa = PBXGroup;
 			children = (
 				09FB2934265FCD7E00752300 /* Person.swift */,
-				C12E7B092661373F008934ED /* Person.xcdatamodeld */,
+				C1801E152665071400D4FBD2 /* PersistenceManager.swift */,
+				C1801E362665125D00D4FBD2 /* Contact.xcdatamodeld */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -68,6 +75,8 @@
 		6B87C4672653EE750000A70A = {
 			isa = PBXGroup;
 			children = (
+				C1801E3A266512BD00D4FBD2 /* Contact+CoreDataClass.swift */,
+				C1801E3B266512BD00D4FBD2 /* Contact+CoreDataProperties.swift */,
 				6B87C4722653EE750000A70A /* SimpleContact */,
 				6B87C4712653EE750000A70A /* Products */,
 			);
@@ -182,12 +191,15 @@
 			files = (
 				0956E6642653FFED00D5B4F9 /* EditViewController.swift in Sources */,
 				0958A30D2654D00100D054CD /* EditView.swift in Sources */,
-				C12E7B0B2661373F008934ED /* Person.xcdatamodeld in Sources */,
 				6B87C4742653EE750000A70A /* AppDelegate.swift in Sources */,
 				6B87C4762653EE750000A70A /* SceneDelegate.swift in Sources */,
+				C1801E3C266512BD00D4FBD2 /* Contact+CoreDataClass.swift in Sources */,
 				09FB2935265FCD7E00752300 /* Person.swift in Sources */,
+				C1801E3D266512BD00D4FBD2 /* Contact+CoreDataProperties.swift in Sources */,
+				C1801E382665125D00D4FBD2 /* Contact.xcdatamodeld in Sources */,
 				0958A30F2657BE7400D054CD /* MainViewController.swift in Sources */,
 				09FB2931265FCCFC00752300 /* MainViewTableViewCell.swift in Sources */,
+				C1801E162665071400D4FBD2 /* PersistenceManager.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -404,13 +416,13 @@
 /* End XCSwiftPackageProductDependency section */
 
 /* Begin XCVersionGroup section */
-		C12E7B092661373F008934ED /* Person.xcdatamodeld */ = {
+		C1801E362665125D00D4FBD2 /* Contact.xcdatamodeld */ = {
 			isa = XCVersionGroup;
 			children = (
-				C12E7B0A2661373F008934ED /* Person.xcdatamodel */,
+				C1801E372665125D00D4FBD2 /* Contact.xcdatamodel */,
 			);
-			currentVersion = C12E7B0A2661373F008934ED /* Person.xcdatamodel */;
-			path = Person.xcdatamodeld;
+			currentVersion = C1801E372665125D00D4FBD2 /* Contact.xcdatamodel */;
+			path = Contact.xcdatamodeld;
 			sourceTree = "<group>";
 			versionGroupType = wrapper.xcdatamodel;
 		};

--- a/SimpleContact/AppDelegate.swift
+++ b/SimpleContact/AppDelegate.swift
@@ -30,6 +30,50 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
         // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
     }
+    // MARK: - Core Data stack
+
+    lazy var persistentContainer: NSPersistentContainer = {
+        /*
+         The persistent container for the application. This implementation
+         creates and returns a container, having loaded the store for the
+         application to it. This property is optional since there are legitimate
+         error conditions that could cause the creation of the store to fail.
+        */
+        let container = NSPersistentContainer(name: "test")
+        container.loadPersistentStores(completionHandler: { (storeDescription, error) in
+            if let error = error as NSError? {
+                // Replace this implementation with code to handle the error appropriately.
+                // fatalError() causes the application to generate a crash log and terminate. You should not use this function in a shipping application, although it may be useful during development.
+                 
+                /*
+                 Typical reasons for an error here include:
+                 * The parent directory does not exist, cannot be created, or disallows writing.
+                 * The persistent store is not accessible, due to permissions or data protection when the device is locked.
+                 * The device is out of space.
+                 * The store could not be migrated to the current model version.
+                 Check the error message to determine what the actual problem was.
+                 */
+                fatalError("Unresolved error \(error), \(error.userInfo)")
+            }
+        })
+        return container
+    }()
+
+    // MARK: - Core Data Saving support
+
+    func saveContext () {
+        let context = persistentContainer.viewContext
+        if context.hasChanges {
+            do {
+                try context.save()
+            } catch {
+                // Replace this implementation with code to handle the error appropriately.
+                // fatalError() causes the application to generate a crash log and terminate. You should not use this function in a shipping application, although it may be useful during development.
+                let nserror = error as NSError
+                fatalError("Unresolved error \(nserror), \(nserror.userInfo)")
+            }
+        }
+    }
 
 
 }

--- a/SimpleContact/AppDelegate.swift
+++ b/SimpleContact/AppDelegate.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import CoreData
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
@@ -39,7 +40,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
          application to it. This property is optional since there are legitimate
          error conditions that could cause the creation of the store to fail.
         */
-        let container = NSPersistentContainer(name: "test")
+        let container = NSPersistentContainer(name: "Contact")
         container.loadPersistentStores(completionHandler: { (storeDescription, error) in
             if let error = error as NSError? {
                 // Replace this implementation with code to handle the error appropriately.

--- a/SimpleContact/Controller/EditViewController.swift
+++ b/SimpleContact/Controller/EditViewController.swift
@@ -129,6 +129,10 @@ class EditViewController: UIViewController {
     
     @objc private func save(_ sender: Any){
         print("save 클릭")
+        //TODO UI 값 가져와서 Person instance 생성하기
+        let person = Person(name: "test", phone: "010-1234-1234", favorite: true, memo: "memo")
+        PersistenceManager.shared.create(person: person)
+
     }
     
     @objc private func addPhoto(_ sender: UIButton){

--- a/SimpleContact/Controller/EditViewController.swift
+++ b/SimpleContact/Controller/EditViewController.swift
@@ -136,6 +136,7 @@ class EditViewController: UIViewController {
     }
     
     @objc private func clickYes(_ sender: UIButton){
+        // 저장
         print("yes")
     }
     

--- a/SimpleContact/Controller/MainViewController.swift
+++ b/SimpleContact/Controller/MainViewController.swift
@@ -70,12 +70,7 @@ class MainViewController: UIViewController {
         return stackView
     }()
     
-    private let dummyData: [Person] = [
-        Person(name: "가나다", phone: "010-1234-5678", favorite: false, memo: "한 줄 텍스트"),
-        Person(name: "홍길동", phone: "010-3456-7890", favorite: false, memo: "두 줄 텍스트를 출력해볼게요. 두줄입니다."),
-        Person(name: "좋아요", phone: "010-5555-5555", favorite: true, memo: "이번엔 세 줄의 텍스트를 출력해볼까요? 세 줄의 텍스트를 출력해보겠습니다."),
-        Person(name: "개발자", phone: "010-2468-1357", favorite: false, memo: "네줄네줄네줄네줄네줄네줄네줄네줄네줄네줄네줄네줄네줄네줄네줄네줄네줄네줄네줄네줄네줄네줄네줄네줄")
-    ]
+    private let dummyData: [Person] = PersistenceManager.shared.read()
     
     // MARK: - Lifecycle
 

--- a/SimpleContact/Model/Contact.xcdatamodeld/Contact.xcdatamodel/contents
+++ b/SimpleContact/Model/Contact.xcdatamodeld/Contact.xcdatamodel/contents
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="17709" systemVersion="19H15" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
-    <entity name="Entity" representedClassName="Entity" syncable="YES" codeGenerationType="class">
+    <entity name="Contact" representedClassName="Contact" syncable="YES">
         <attribute name="favorite" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="memo" optional="YES" attributeType="String"/>
         <attribute name="name" optional="YES" attributeType="String"/>
         <attribute name="phone" optional="YES" attributeType="String"/>
     </entity>
     <elements>
-        <element name="Entity" positionX="-54" positionY="-9" width="128" height="103"/>
+        <element name="Contact" positionX="-63" positionY="-18" width="128" height="103"/>
     </elements>
 </model>

--- a/SimpleContact/Model/PersistenceManager.swift
+++ b/SimpleContact/Model/PersistenceManager.swift
@@ -1,0 +1,77 @@
+//
+//  PersistenceManager.swift
+//  SimpleContact
+//
+//  Created by 김두리 on 2021/05/31.
+//
+
+import Foundation
+import CoreData
+
+class PersistenceManager {
+    static var shared: PersistenceManager = PersistenceManager()
+    
+    lazy var persistentContainer: NSPersistentContainer = {
+        let container = NSPersistentContainer(name: "Contact")
+        container.loadPersistentStores(completionHandler: {
+            (storeDescription, error) in
+            if let error = error as NSError? {
+                fatalError("Unresolved error \(error), \(error.userInfo)")
+            }
+        })
+        return container
+    }()
+    
+    var context: NSManagedObjectContext {
+        return self.persistentContainer.viewContext
+    }
+    
+    func create(person: Person) -> Void {
+        let entity = NSEntityDescription.entity(forEntityName: "Contact", in: self.context)
+        
+        if let entity = entity {
+            let manageObject = NSManagedObject(entity: entity, insertInto: self.context)
+            manageObject.setValue(person.name, forKey: "name")
+            manageObject.setValue(person.memo, forKey: "memo")
+            manageObject.setValue(person.phone, forKey: "phone")
+            manageObject.setValue(person.favorite, forKey: "favorite")
+            
+            do {
+                try self.context.save()
+            } catch {
+                print(error.localizedDescription)
+            }
+        }
+    }
+    
+    func read() -> [Person] {
+        let readRequest = NSFetchRequest<NSManagedObject>(entityName: "Contact")
+        
+        let personData = try! context.fetch(readRequest)
+    
+        var dataToPerson = [Person]()
+        print(personData.count)
+        
+        for data in personData{
+            let name = data.value(forKey: "name") as! String
+            let phone = data.value(forKey: "phone") as! String
+            let favorite = data.value(forKey: "favorite") as! Bool
+            let memo = data.value(forKey: "memo") as! String
+            
+            dataToPerson.append(Person(name: name, phone: phone, favorite: favorite, memo: memo))
+        }
+        
+        return dataToPerson
+    }
+    
+    // TODO edit person info
+    func update(person: Person) -> Person {
+        return person
+    }
+    
+    //TODO delete Person
+    func delete(person: Person) -> Bool {
+        
+        return true
+    }
+}

--- a/SimpleContact/Model/Person.swift
+++ b/SimpleContact/Model/Person.swift
@@ -1,4 +1,4 @@
-//
+
 //  Person.swift
 //  SimpleContact
 //
@@ -7,9 +7,14 @@
 
 import Foundation
 
-struct Person {
+struct Person: Equatable{
     var name: String
     var phone: String
     var favorite: Bool
     var memo: String
+    
+    static func ==(left: Person, right: Person) -> Bool {
+        return left.name == right.name && left.phone == right.phone
+    }
 }
+

--- a/SimpleContact/Model/Person.xcdatamodeld/Person.xcdatamodel/contents
+++ b/SimpleContact/Model/Person.xcdatamodeld/Person.xcdatamodel/contents
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="17709" systemVersion="19H15" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+    <entity name="Entity" representedClassName="Entity" syncable="YES" codeGenerationType="class">
+        <attribute name="favorite" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="memo" optional="YES" attributeType="String"/>
+        <attribute name="name" optional="YES" attributeType="String"/>
+        <attribute name="phone" optional="YES" attributeType="String"/>
+    </entity>
+    <elements>
+        <element name="Entity" positionX="-54" positionY="-9" width="128" height="103"/>
+    </elements>
+</model>

--- a/SimpleContact/SceneDelegate.swift
+++ b/SimpleContact/SceneDelegate.swift
@@ -62,6 +62,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // Called as the scene transitions from the foreground to the background.
         // Use this method to save data, release shared resources, and store enough scene-specific state information
         // to restore the scene back to its current state.
+        (UIApplication.shared.delegate as? AppDelegate)?.saveContext()
     }
 
 


### PR DESCRIPTION
## 작업 내용(자세히!)
작업은 크게 3부분 하였습니다.
- CoreData 설정 (AppDelegate)
- Entity 생성 (Contact)
- DAO 생성을 통한 비즈니스 로직 (create, read) 구현

### 1. CoreData 설정 (AppDelegate.swift)
처음 프로젝트를 생성하였을 때, CoreData를 체크를 안해주어서 (ㅠㅠ)
persistent Container 부분 설정해주었습니다.
** 주요 내용은 **Contact** 를 불러오고, 해당 컨텍스트를 저장한다는 내용입니다. 

### 2. Entity 생성 (Contact)
CoreData 파일 생성 시 Contact.xcdatamodeld 파일이 생성되고, Contact 엔티티 생성해 주었습니다.

attribute로는 기존의 Person Type과 동일하게 해주었으며, Person struct와 구분을 위해 이름을 Contact로 해주었습니다.

### 3.  DAO 생성을 통한 비즈니스 로직 (create, read) 구현
DAO(data access object) 클래스 개념으로 PersistenceManager 클래스를 만들었습니다.
따라서, 해당 클래스 내에서 싱글톤을 통해 비즈니스 로직을 위한 데이터 처리를 구현하였습니다.

1. create
CoreData의 경우 독특하게 레코드 저장 방식으로 NSManagedObject class를 사용해서,
하나의 오브젝트 = Person 오브젝트 느낌으로 setValue 해주었습니다.

2. read
read 함수의 반환형으로 Person의 array가 나옵니다. 따라서, 현재 컨텍스트를 모두 읽어와, Person type으로 바꾸는 로직이 필요했고, for 문에서 확인하실 수 있습니다.

### 아맞다, 참고로 delete와 update 부분 하기 쉽도록 Person struct에 Equtable 추가하였습니다!! 
### 그리고 create 부분은 UI Label이 텍스트를 제대로 못 가져와서 테스트겸 임의 값 넣어서 로직만 수행하도록 했습니다. 참고해주세용~



## 결과(스크린샷 또는 기대결과)
![image](https://user-images.githubusercontent.com/26545623/120202728-e389b080-c261-11eb-83a5-e9f237ccc9f6.png)
![image](https://user-images.githubusercontent.com/26545623/120202403-842ba080-c261-11eb-98b4-3e2b562b653f.png)
